### PR TITLE
The Big Reformat

### DIFF
--- a/wiki/addons/first-party/kubejs-create/page.kubedoc
+++ b/wiki/addons/first-party/kubejs-create/page.kubedoc
@@ -21,12 +21,12 @@ Features:
 - supports chance-based output
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.compacting('diamond', 'coal_block')
-  e.recipes.create.compacting('diamond', 'coal_block').heated()
-  e.recipes.create.compacting('diamond', 'coal_block').superheated()
-  e.recipes.create.compacting([Fluid.water(10), 'dead_bush'], ['#minecraft:saplings', '#minecraft:saplings'])
-  e.recipes.create.compacting(['diamond', Item.of('diamond').withChance(0.3)], 'coal_block')
+ServerEvents.recipes(event => {
+  event.recipes.create.compacting('minecraft:diamond', 'minecraft:coal_block')
+  event.recipes.create.compacting('minecraft:diamond', 'minecraft:coal_block').heated()
+  event.recipes.create.compacting('minecraft:diamond', 'minecraft:coal_block').superheated()
+  event.recipes.create.compacting([Fluid.water(10), 'minecraft:dead_bush'], ['#minecraft:saplings', '#minecraft:saplings'])
+  event.recipes.create.compacting(['minecraft:diamond', Item.of('minecraft:diamond').withChance(0.3)], 'minecraft:coal_block')
 })
 ```
 
@@ -43,10 +43,10 @@ Features:
 - supports `.processingTime()`
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.crushing('diamond', 'coal_block')
-  e.recipes.create.crushing('diamond', 'coal_block').processingTime(500)
-  e.recipes.create.crushing(['diamond', Item.of('diamond').withChance(0.5)], 'coal_block')
+ServerEvents.recipes(event => {
+  event.recipes.create.crushing('minecraft:diamond', 'minecraft:coal_block')
+  event.recipes.create.crushing('minecraft:diamond', 'minecraft:coal_block').processingTime(500)
+  event.recipes.create.crushing(['minecraft:diamond', Item.of('minecraft:diamond').withChance(0.5)], 'minecraft:coal_block')
 })
 ```
 
@@ -63,10 +63,10 @@ Features:
 - supports `.processingTime()`
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.cutting('diamond', 'coal_block')
-  e.recipes.create.cutting('diamond', 'coal_block').processingTime(500)
-  e.recipes.create.cutting(['diamond', Item.of('diamond').withChance(0.5)], 'coal_block')
+ServerEvents.recipes(event => {
+  event.recipes.create.cutting('minecraft:diamond', 'minecraft:coal_block')
+  event.recipes.create.cutting('minecraft:diamond', 'minecraft:coal_block').processingTime(500)
+  event.recipes.create.cutting(['minecraft:diamond', Item.of('minecraft:diamond').withChance(0.5)], 'minecraft:coal_block')
 })
 ```
 
@@ -84,10 +84,10 @@ Features:
 - supports `.keepHeldItem()`
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.deploying('diamond', ['coal_block', 'sand'])
-  e.recipes.create.deploying(['diamond', 'emerald'], ['coal_block', 'sand']).keepHeldItem()
-  e.recipes.create.deploying(['diamond', Item.of('diamond').withChance(0.5)], ['coal_block', 'sand'])
+ServerEvents.recipes(event => {
+  event.recipes.create.deploying('minecraft:diamond', ['minecraft:coal_block', 'minecraft:sand'])
+  event.recipes.create.deploying(['minecraft:diamond', 'minecraft:emerald'], ['minecraft:coal_block', 'minecraft:sand']).keepHeldItem()
+  event.recipes.create.deploying(['minecraft:diamond', Item.of('minecraft:diamond').withChance(0.5)], ['minecraft:coal_block', 'minecraft:sand'])
 })
 ```
 
@@ -103,8 +103,8 @@ Features:
 - requires one input and two outputs, the outputs must be an item and a fluid
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.emptying([Fluid.water(), 'bucket'], 'water_bucket')
+ServerEvents.recipes(event => {
+  event.recipes.create.emptying([Fluid.water(), 'minecraft:bucket'], 'minecraft:water_bucket')
 })
 ```
 
@@ -120,8 +120,8 @@ Features:
 - requires two inputs and one output, the inputs must be an item and a fluid
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.filling('water_bucket', [Fluid.water(), 'bucket'])
+ServerEvents.recipes(event => {
+  event.recipes.create.filling('minecraft:water_bucket', [Fluid.water(), 'minecraft:bucket'])
 })
 ```
 
@@ -137,10 +137,10 @@ Features:
 - supports multiple chance-based outputs
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.haunting('soul_campfire', 'campfire')
-  e.recipes.create.haunting(['wheat', 'oak_sapling'], 'potato')
-  e.recipes.create.haunting(['wheat', Item.of('oak_sapling').withChance(0.2)], 'potato')
+ServerEvents.recipes(event => {
+  event.recipes.create.haunting('minecraft:soul_campfire', 'minecraft:campfire')
+  event.recipes.create.haunting(['minecraft:wheat', 'minecraft:oak_sapling'], 'minecraft:potato')
+  event.recipes.create.haunting(['minecraft:wheat', Item.of('minecraft:oak_sapling').withChance(0.2)], 'minecraft:potato')
 })
 ```
 
@@ -157,15 +157,15 @@ Features:
 - supports up to 9x9 grid size
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.mechanical_crafting('emerald', [
+ServerEvents.recipes(event => {
+  event.recipes.create.mechanical_crafting('minecraft:emerald', [
     ' DDD ',
     'D   D',
     'D   D',
     'D   D',
     ' DDD '
   ], {
-    D: 'dirt'
+    D: 'minecraft:dirt'
   })
 })
 ```
@@ -181,10 +181,10 @@ Features:
 - supports multiple chance-based outputs
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.milling('diamond', 'coal_block')
-  e.recipes.create.milling(['diamond', 'emerald'], 'coal_block')
-  e.recipes.create.milling(['diamond', Item.of('diamond').withChance(0.5)], 'coal_block')
+ServerEvents.recipes(event => {
+  event.recipes.create.milling('minecraft:diamond', 'minecraft:coal_block')
+  event.recipes.create.milling(['minecraft:diamond', 'minecraft:emerald'], 'minecraft:coal_block')
+  event.recipes.create.milling(['minecraft:diamond', Item.of('minecraft:diamond').withChance(0.5)], 'minecraft:coal_block')
 })
 ```
 
@@ -201,12 +201,12 @@ Features:
 - supports `.heated()` and `.superheated()`
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.mixing('diamond', 'coal_block')
-  e.recipes.create.mixing('diamond', 'coal_block').heated()
-  e.recipes.create.mixing('diamond', 'coal_block').superheated()
-  e.recipes.create.mixing([Fluid.water(10), 'dead_bush'], ['#minecraft:saplings', '#minecraft:saplings'])
-  e.recipes.create.mixing(['diamond', Item.of('diamond').withChance(0.3)], 'coal_block')
+ServerEvents.recipes(event => {
+  event.recipes.create.mixing('minecraft:diamond', 'minecraft:coal_block')
+  event.recipes.create.mixing('minecraft:diamond', 'minecraft:coal_block').heated()
+  event.recipes.create.mixing('minecraft:diamond', 'minecraft:coal_block').superheated()
+  event.recipes.create.mixing([Fluid.water(10), 'minecraft:dead_bush'], ['#minecraft:saplings', '#minecraft:saplings'])
+  event.recipes.create.mixing(['minecraft:diamond', Item.of('minecraft:diamond').withChance(0.3)], 'minecraft:coal_block')
 })
 ```
 
@@ -222,10 +222,10 @@ Features:
 - supports multiple chance-based outputs
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.pressing('diamond', 'coal_block')
-  e.recipes.create.pressing(['diamond', 'emerald'], 'coal_block')
-  e.recipes.create.pressing(['diamond', Item.of('diamond').withChance(0.5)], 'coal_block')
+ServerEvents.recipes(event => {
+  event.recipes.create.pressing('minecraft:diamond', 'minecraft:coal_block')
+  event.recipes.create.pressing(['minecraft:diamond', 'minecraft:emerald'], 'minecraft:coal_block')
+  event.recipes.create.pressing(['minecraft:diamond', Item.of('minecraft:diamond').withChance(0.5)], 'minecraft:coal_block')
 })
 ```
 
@@ -243,9 +243,9 @@ Features:
 - supports chance-based output
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.sandpaper_polishing('diamond', 'coal_block')
-  e.recipes.create.sandpaper_polishing(Item.of('diamond').withChance(0.5), 'coal_block')
+ServerEvents.recipes(event => {
+  event.recipes.create.sandpaper_polishing('minecraft:diamond', 'minecraft:coal_block')
+  event.recipes.create.sandpaper_polishing(Item.of('minecraft:diamond').withChance(0.5), 'minecraft:coal_block')
 })
 ```
 
@@ -272,45 +272,45 @@ The transitional item needs to be the input ***and*** output of each of these re
 `Loops` is the number of times that the recipe repeats. Calling `.loops()` is optional and defaults to **4**.
 
 ```js
-ServerEvents.recipes(e => {
-	e.recipes.create.sequenced_assembly([
+ServerEvents.recipes(event => {
+	event.recipes.create.sequenced_assembly([
 		Item.of('create:precision_mechanism').withChance(130.0), // this is the item that will appear in JEI as the result
 		Item.of('create:golden_sheet').withChance(8.0), // the rest of these items will be part of the scrap
 		Item.of('create:andesite_alloy').withChance(8.0),
 		Item.of('create:cogwheel').withChance(5.0),
 		Item.of('create:shaft').withChance(2.0),
 		Item.of('create:crushed_gold_ore').withChance(2.0),
-		Item.of('2x gold_nugget').withChance(2.0),
-		'iron_ingot',
-		'clock'
+		Item.of('2x minecraft:gold_nugget').withChance(2.0),
+		'minecraft:iron_ingot',
+		'minecraft:clock'
 	], 'create:golden_sheet', [ // 'create:golden_sheet' is the input
 		// the transitional item set by `transitionalItem('create:incomplete_large_cogwheel')` is the item used during the intermediate stages of the assembly
-		e.recipes.createDeploying('create:incomplete_precision_mechanism', ['create:incomplete_precision_mechanism', 'create:cogwheel']),
+		event.recipes.createDeploying('create:incomplete_precision_mechanism', ['create:incomplete_precision_mechanism', 'create:cogwheel']),
 		// like a normal recipe function, is used as a sequence step in this array. Input and output have the transitional item
-		e.recipes.createDeploying('create:incomplete_precision_mechanism', ['create:incomplete_precision_mechanism', 'create:large_cogwheel']),
-		e.recipes.createDeploying('create:incomplete_precision_mechanism', ['create:incomplete_precision_mechanism', 'create:iron_nugget'])
+		event.recipes.createDeploying('create:incomplete_precision_mechanism', ['create:incomplete_precision_mechanism', 'create:large_cogwheel']),
+		event.recipes.createDeploying('create:incomplete_precision_mechanism', ['create:incomplete_precision_mechanism', 'minecraft:iron_nugget'])
 	]).transitionalItem('create:incomplete_precision_mechanism').loops(5) // set the transitional item and the number of loops
 
 	// for this code to work, kubejs:incomplete_spore_blossom needs to be added to the game
 	let inter = 'kubejs:incomplete_spore_blossom' // making a variable to store the transitional item makes the code more readable
-	e.recipes.create.sequenced_assembly([
-		Item.of('spore_blossom').withChance(16.0), // this is the item that will appear in JEI as the result
-		Item.of('flowering_azalea_leaves').withChance(16.0), // the rest of these items will be part of the scrap
-		Item.of('azalea_leaves').withChance(2.0),
-		'oak_leaves',
-		'spruce_leaves',
-		'birch_leaves',
-		'jungle_leaves',
-		'acacia_leaves',
-		'dark_oak_leaves'
-	], 'flowering_azalea_leaves', [ // 'flowering_azalea_leaves' is the input
+	event.recipes.create.sequenced_assembly([
+		Item.of('minecraft:spore_blossom').withChance(16.0), // this is the item that will appear in JEI as the result
+		Item.of('minecraft:flowering_azalea_leaves').withChance(16.0), // the rest of these items will be part of the scrap
+		Item.of('minecraft:azalea_leaves').withChance(2.0),
+		'minecraft:oak_leaves',
+		'minecraft:spruce_leaves',
+		'minecraft:birch_leaves',
+		'minecraft:jungle_leaves',
+		'minecraft:acacia_leaves',
+		'minecraft:dark_oak_leaves'
+	], 'minecraft:flowering_azalea_leaves', [ // 'minecraft:flowering_azalea_leaves' is the input
 		// the transitional item is a variable, that is 'kubejs:incomplete_spore_blossom' and is used during the intermediate stages of the assembly
-		e.recipes.createPressing(inter, inter),
+		event.recipes.createPressing(inter, inter),
 		// like a normal recipe function, is used as a sequence step in this array. Input and output have the transitional item
-		e.recipes.createDeploying(inter, [inter, 'minecraft:hanging_roots']),
-		e.recipes.createFilling(inter, [inter, Fluid.water(420)]),
-		e.recipes.createDeploying(inter, [inter, 'minecraft:moss_carpet']),
-		e.recipes.createCutting(inter, inter)
+		event.recipes.createDeploying(inter, [inter, 'minecraft:hanging_roots']),
+		event.recipes.createFilling(inter, [inter, Fluid.water(420)]),
+		event.recipes.createDeploying(inter, [inter, 'minecraft:moss_carpet']),
+		event.recipes.createCutting(inter, inter)
 	]).transitionalItem(inter).loops(2) // set the transitional item and the number of loops
 })
 ```
@@ -340,10 +340,10 @@ Features:
 - uses the 
 
 ```js
-ServerEvents.recipes(e => {
-  e.recipes.create.splashing('soul_campfire', 'campfire')
-  e.recipes.create.splashing(['wheat', 'oak_sapling'], 'potato')
-  e.recipes.create.splashing(['wheat', Item.of('oak_sapling').withChance(0.2)], 'potato')
+ServerEvents.recipes(event => {
+  event.recipes.create.splashing('minecraft:soul_campfire', 'minecraft:campfire')
+  event.recipes.create.splashing(['minecraft:wheat', 'minecraft:oak_sapling'], 'minecraft:potato')
+  event.recipes.create.splashing(['minecraft:wheat', Item.of('minecraft:oak_sapling').withChance(0.2)], 'minecraft:potato')
 })
 ```
 
@@ -357,8 +357,8 @@ Mysterious Conversion recipes go in {cl-s}, outside of any event listeners. Curr
 let $MysteriousItemConversionCategory = Java.loadClass('com.simibubi.create.compat.jei.category.MysteriousItemConversionCategory')
 let $ConversionRecipe = Java.loadClass('com.simibubi.create.compat.jei.ConversionRecipe')
 
-$MysteriousItemConversionCategory.RECIPES.add($ConversionRecipe.create('apple', 'carrot'))
-$MysteriousItemConversionCategory.RECIPES.add($ConversionRecipe.create('golden_apple', 'golden_carrot'))
+$MysteriousItemConversionCategory.RECIPES.add($ConversionRecipe.create('minecraft:apple', 'minecraft:carrot'))
+$MysteriousItemConversionCategory.RECIPES.add($ConversionRecipe.create('minecraft:golden_apple', 'minecraft:golden_carrot'))
 ```
 
 # Preventing Recipe Auto-Generation
@@ -366,8 +366,8 @@ $MysteriousItemConversionCategory.RECIPES.add($ConversionRecipe.create('golden_a
 If you don't want smelting, blasting, smoking, crafting, or stonecutting to get an auto-generated counterpart, then include `manual_only` at the end of the recipe id:
 
 ```js
-ServerEvents.recipes(e => {
-	e.shapeless('wet_sponge', ['water_bucket', 'sponge']).id('kubejs:moisting_the_sponge_manual_only')
+ServerEvents.recipes(event => {
+	event.shapeless('minecraft:wet_sponge', ['minecraft:water_bucket', 'minecraft:sponge']).id('kubejs:moisting_the_sponge_manual_only')
 })
 ```
 

--- a/wiki/addons/first-party/kubejs-immersive-engineering/page.kubedoc
+++ b/wiki/addons/first-party/kubejs-immersive-engineering/page.kubedoc
@@ -2,80 +2,99 @@ Download: [CurseForge](https://www.curseforge.com/minecraft/mc-mods/kubejs-immer
 
 ---
 
-Supported Recipe Types:
+# Supported Recipe Types
 
-- Alloy Kiln
+## Alloy Kiln
 ```js
 event.recipes.immersiveengineering.alloy(output, input1, input2)
 event.recipes.immersiveengineering.alloy(output, input1, input2, time)
 ```
-- Blast Furnace
+
+## Blast Furnace
 ```js
 event.recipes.immersiveengineering.blast_furnace(output, input)
 event.recipes.immersiveengineering.blast_furnace(output, input, slag)
 ```
-- Blast Furnace Fuel
+
+## Blast Furnace Fuel
 ```js
 event.recipes.immersiveengineering.blast_furnace_fuel(input, time)
 ```
-- Coke Oven
+
+## Coke Oven
 ```js
 event.recipes.immersiveengineering.coke_oven(output, input, creosote)
 event.recipes.immersiveengineering.coke_oven(output, input, creosote, time)
 ```
-- Garden Cloche
+
+## Garden Cloche
+>>> warn
+This is currently broken on 1.19!
+<<<
+`render` format: `{type: 'crop', block: 'minecraft:wheat'}`
 ```js
-event.recipes.immersiveengineering.cloche([outputs], input, soil) //CURRENTLY BROKEN ON 1.19
-event.recipes.immersiveengineering.cloche([outputs], input, soil, render) // Render format: {type: 'crop', block: 'minecraft:wheat'}
+event.recipes.immersiveengineering.cloche([outputs], input, soil)
+event.recipes.immersiveengineering.cloche([outputs], input, soil, render)
 ```
-- Fertilizer
+
+## Fertilizer
 ```js
 event.recipes.immersiveengineering.fertilizer(input, growthModifier)
 ```
-- Metal Press
+
+## Metal Press
 ```js
 event.recipes.immersiveengineering.metal_press(output, input, mold)
 ```
-- Arc Furnace
+
+## Arc Furnace
 ```js
 event.recipes.immersiveengineering.arc_furnace([outputs], input)
 event.recipes.immersiveengineering.arc_furnace([outputs], input, [additives])
 event.recipes.immersiveengineering.arc_furnace([outputs], input, [additives], slag)
 ```
-- Crusher
+
+## Crusher
+`secondaries` format: `{chance: 0.5, output: 'item:id'}`
 ```js
 event.recipes.immersiveengineering.crusher(output, input)
-event.recipes.immersiveengineering.crusher(output, input, [secondaries]) // Secondary output format: {chance: 0.5, output: 'item:id'}
+event.recipes.immersiveengineering.crusher(output, input, [secondaries])
 ```
-- Sawmill
+
+## Sawmill
+`secondaries` format: `{stripping: true, output: 'item:id'}`
 ```js
 event.recipes.immersiveengineering.sawmill(output, input)
-event.recipes.immersiveengineering.sawmill(output, input, [secondaries]) // Secondary output format: {stripping: true, output: 'item:id'}
+event.recipes.immersiveengineering.sawmill(output, input, [secondaries])
 event.recipes.immersiveengineering.sawmill(output, input, [secondaries], stripped)
 ```
-- Fermenter
+
+## Fermenter
 ```js
 event.recipes.immersiveengineering.fermenter(input, fluid, output)
 ```
-- Blueprint (Engineer's Workbench)
-```js
-event.recipes.immersiveengineering.blueprint(output, [inputs], blueprint) //"blueprint" is NOT AN ITEM, it is the Category name.
-```
->>> info
-Blueprint Categories:
-"bannerpatterns"
-"bullet"
-"specialBullet"
-"components"
-"molds"
-"electrode"
-<<<
 
->>> warn
-**Some recipe types don't work currently! Use `event.custom`**.
-Bottling Machine
-Mixer
-Refinery
-Squeezer
-Thermoelectric Source
-<<<
+## Blueprint (Engineer's Workbench)
+`blueprint` is a blueprint category name.
+```js
+event.recipes.immersiveengineering.blueprint(output, [inputs], blueprint)
+```
+
+### Blueprint Categories
+As stated above, in `blueprint` you have to use a category name. These are the default ones:
+- `bannerpatterns`
+- `bullet`
+- `specialBullet`
+- `components`
+- `molds`
+- `electrode`
+
+# Broken Recipe Types
+These recipe types are currently broken:
+- Bottling Machine
+- Mixer
+- Refinery
+- Squeezer
+- Thermoelectric Source
+
+For now, use `event.custom` for these.

--- a/wiki/addons/first-party/kubejs-mekanism/page.kubedoc
+++ b/wiki/addons/first-party/kubejs-mekanism/page.kubedoc
@@ -2,79 +2,79 @@ Download: [CurseForge](https://www.curseforge.com/minecraft/mc-mods/kubejs-mekan
 
 ---
 
-Supported Recipe Types:
+# Supported Recipe Types:
 
-- Crushing, Enriching, Smelting
+## Crushing, Enriching, Smelting
 ```js
 event.recipes.mekanism.crushing(output, input)
 event.recipes.mekanism.enriching(output, input)
 event.recipes.mekanism.smelting(output, input)
 ```
-- Combining
+## Combining
 ```js
 event.recipes.mekanism.combining(output, input1, input2)
 ```
-- Compressing, Purifying, Injecting
+## Compressing, Purifying, Injecting
 ```js
 event.recipes.mekanism.compressing(output, inputItem, inputGas)
 event.recipes.mekanism.purifying(output, inputItem, inputGas)
 event.recipes.mekanism.injecting(output, inputItem, inputGas)
 ```
-- Infusing
+## Infusing
 ```js
 event.recipes.mekanism.metallurgic_infusing(output, inputItem, infusionInput, infusionAmount)
 ```
-- Sawing
+## Sawing
 ```js
 event.recipes.mekanism.sawing(output, input, extraOutput)
 ```
-- Chemical Infusing
+## Chemical Infusing
 ```js
 event.recipes.mekanism.chemical_infusing(output, inputLeft, inputRight)
 ```
-- Crystallizing
+## Crystallizing
 ```js
 event.recipes.mekanism.crystallizing(output, inputGas)
 ```
-- Dissolution
+## Dissolution
 ```js
 event.recipes.mekanism.dissolution(gasOutput, gasInput, itemInput)
 ```
-- Item > Energy Conversion
+## Item > Energy Conversion
 ```js
 event.recipes.mekanism.energy_conversion(input, output)
 ```
 
->>> warn
-**Some recipe types don't work currently and/or are unsupported! Use `event.custom`**.
-Item > Gas Conversion
-Item > Infuse Type Conversion
-Thermal Evaporation
-Nucleosynthesizing
-Centrifuging
-Activating
-Liquifier
-Oxidizing
-Condensentrating / Decondensentrating
-Painting
-Pigment Mixing
-Pigment Extracting
-Reaction (PRC)
-Separator
-Washing
-Fission Reactor (There's a mod for this! [Mekanism Fission Recipe](https://www.curseforge.com/minecraft/mc-mods/mekanism-fission-recipe))
-**These have no recipe types**:
-Boiler
-Phase Shifter (SPS)
-<<<
+# Broken / Unsupported Recipe Types
+There recipe types are currently broken:
+- Item > Gas Conversion
+- Item > Infuse Type Conversion
+- Thermal Evaporation
+- Nucleosynthesizing
+- Centrifuging
+- Activating
+- Liquifier
+- Oxidizing
+- Condensentrating / Decondensentrating
+- Painting
+- Pigment Mixing
+- Pigment Extracting
+- Reaction (PRC)
+- Separator
+- Washing
+- Fission Reactor ([There's a mod for this!](https://www.curseforge.com/minecraft/mc-mods/mekanism-fission-recipe))
 
-Registry:
+For now, use `event.custom` for these.
 
-```js
-StartupEvents.registry('mekanism:slurry', event => {
-StartupEvents.registry('mekanism:gas', event => {
-StartupEvents.registry('mekanism:infuse_type', event => {
-StartupEvents.registry('mekanism:pigment', event => {
-StartupEvents.registry('mekanism:module', event => {
-StartupEvents.registry('mekanism:robit_skin', event => {
-```
+These have no recipe types:
+- Boiler
+- Phase Shifter (SPS)
+
+# Registries
+You can register these with the addon:
+- `mekanism:slurry`
+- `mekanism:gas`
+- `mekanism:infuse_type`
+- `mekanism:pigment`
+- `mekanism:module`
+- `mekanism:robit_skin`

--- a/wiki/addons/first-party/kubejs-thermal/page.kubedoc
+++ b/wiki/addons/first-party/kubejs-thermal/page.kubedoc
@@ -11,7 +11,7 @@ Supported recipe types:
 - `sawmill`
 - `pulverizer`
 - `smelter`
-- `centrifuge
+- `centrifuge`
 - `press`
 - `crucible`
 - `chiller`

--- a/wiki/addons/third-party/bejs/page.kubedoc
+++ b/wiki/addons/third-party/bejs/page.kubedoc
@@ -16,12 +16,12 @@ StartupEvents.registry('block', event => {
                 if(level.levelData.gameTime % 20 == 0) { // only .levelData.gameTime works for some reason??
                     if(level.getBlockState(pos.above()) === Blocks.AIR.defaultBlockState()) {
                         level.setBlock(pos.above(), Blocks.GLASS.defaultBlockState(), 3)
-                      	be.persistentData.putBoolean("placed", true)
+                      	be.persistentData.putBoolean('placed', true)
                     } else {
                         level.setBlock(pos.above(), Blocks.AIR.defaultBlockState(), 3)
-                        be.persistentData.putBoolean("placed", false)
+                        be.persistentData.putBoolean('placed', false)
                     }
-                  	console.info("placed: " + be.persistentData.getBoolean("placed"))
+                  	console.info('placed: ' + be.persistentData.getBoolean('placed'))
                 }
             }
     	}).defaultValues(tag => tag = { progress: 0, example_value_for_extra_saved_data: '0mG this iz Crazyyy'}) // adds a 'default' saved value, added on block entity creation (place etc)
@@ -52,9 +52,9 @@ StartupEvents.registry('block_entity_type', event => {
             }
         }
     }).saveCallback((level, pos, be, tag) => { // called on BlockEntity save, don't see why you would ever need these tbf, but they're here
-        tag.putInt("tagValueAa", be.getPersistentData().getInt('progress'))
+        tag.putInt('tagValueAa', be.getPersistentData().getInt('progress'))
     }).loadCallback((level, pos, be, tag) => { // called on BlockEntity load, same as above
-          be.getPersistentData().putInt("progress", tag.getInt("tagValueAa"))
+          be.getPersistentData().putInt('progress', tag.getInt('tagValueAa'))
     }).defaultValues(tag => tag = { progress: 0, example_value_for_extra_saved_data: '0mG this iz Crazyyy'}) // adds a 'default' saved value, added on block entity creation (place etc)
                                                                                                               // [1st param: CompoundTag consumer]
     .addValidBlock('example_block') // adds a valid block this can attach to, useless in normal circumstances (except if you want to attach to multible blocks)

--- a/wiki/addons/third-party/kubejs-ars-nouveau/page.kubedoc
+++ b/wiki/addons/third-party/kubejs-ars-nouveau/page.kubedoc
@@ -6,25 +6,25 @@ This addon allows you to create recipes for the [Ars Nouveau](https://www.cursef
 ```js
 ServerEvents.recipes(event => {
     event.recipes.ars_nouveau.enchanting_apparatus(
-        ['sand', 'sand', 'sand', 'sand'], // input items
-        'gunpowder', // reagent
-        'tnt', // output
+        ['minecraft:sand', 'minecraft:sand', 'minecraft:sand', 'minecraft:sand'], // input items
+        'minecraft:gunpowder', // reagent
+        'minecraft:tnt', // output
         1000 // source cost
         // true // keep nbt of reagent, think like a smithing recipe
     )
 
     event.recipes.ars_nouveau.enchantment(
-        ['sand', 'sand', 'sand', 'sand'], // input items
-        'vanishing_curse', // applied enchantment
+        ['minecraft:sand', 'minecraft:sand', 'minecraft:sand', 'minecraft:sand'], // input items
+        'minecraft:vanishing_curse', // applied enchantment
         1, // enchantment level
         1000 // source cost
     )
 
     event.recipes.ars_nouveau.crush(
-        'tnt', // input block
+        'minecraft:tnt', // input block
         [
-            Item.of('sand').withChance(1.0)
-            //{ item: Item.of("sand").withChance(1.0), maxRolls: 4 }
+            Item.of('minecraft:sand').withChance(1.0)
+            //{ item: Item.of('minecraft:sand').withChance(1.0), maxRolls: 4 }
         ] // loot table
         // true // drop the item in world?
     )
@@ -34,8 +34,8 @@ ServerEvents.recipes(event => {
     // in the tome, so this really can only be used to
     // replace a glyph's recipe
     event.recipes.ars_nouveau.glyph(
-        'tnt', // output item (glyph)
-        ['sand', 'gunpowder'], // input items
+        'minecraft:tnt', // output item (glyph)
+        ['minecraft:sand', 'minecraft:gunpowder'], // input items
         3 // exp cost
     )
     */
@@ -51,7 +51,7 @@ ServerEvents.recipes(event => {
                 'ars_nouveau:glyph_extend_time',
                 'ars_nouveau:glyph_light'
             ], //spell
-            "Doesn't snare the target and grant other targets Glowing.", // description
+            'Doesn\'t snare the target and grant other targets Glowing.', // description
             16718260, // color
             {
                 family: 'ars_nouveau:default',
@@ -62,15 +62,15 @@ ServerEvents.recipes(event => {
         .id('kubejs:not_glow')
 
     event.recipes.ars_nouveau.imbuement(
-        'sand', // input item
-        'tnt', // output
+        'minecraft:sand', // input item
+        'minecraft:tnt', // output
         1000, // source cost
         []
     )
 
     event.recipes.ars_nouveau.imbuement(
-        'red_sand', // input item
-        'tnt', // output
+        'minecraft:red_sand', // input item
+        'minecraft:tnt', // output
         1000, // source cost
         []
     )

--- a/wiki/addons/third-party/kubejs-botany-pots/page.kubedoc
+++ b/wiki/addons/third-party/kubejs-botany-pots/page.kubedoc
@@ -6,14 +6,14 @@ This addon allows you to create crops, soils, and fertilizers for the [Botany Po
 ```js
 ServerEvents.recipes(event => {
     event.recipes.botanypots.crop(
-        'candle', // seed item
-        ['oak_leaves'], // categories that this crop can be planted on
+        'minecraft:candle', // seed item
+        ['minecraft:oak_leaves'], // categories that this crop can be planted on
         10, // growthTicks
         1, // growthModifier - this can be set to 1 in most cases
-        { block: 'candle' }, // display block
+        { block: 'minecraft:candle' }, // display block
         [
             {
-                output: 'candle', // item
+                output: 'minecraft:candle', // item
                 chance: 100, // weight of this entry compared to the others
                 minRolls: 1, // the minimum times this loot will be chosen
                 maxRolls: 2 // the maximum times this loot will be chosen
@@ -23,15 +23,15 @@ ServerEvents.recipes(event => {
     )
 
     event.recipes.botanypots.soil(
-        'oak_leaves', // the item that this soil is attached to
-        { block: 'oak_leaves' }, // display block
-        ['oak_leaves'], // categories that this soil provides
+        'minecraft:oak_leaves', // the item that this soil is attached to
+        { block: 'minecraft:oak_leaves' }, // display block
+        ['minecraft:oak_leaves'], // categories that this soil provides
         100, // growth ticks that this soil will provide, set to -1 for no modifier
         0.5 // optional, growth modifier, example: 0.5 means all crops will take half the time
     )
 
     event.recipes.botanypots.fertilizer(
-        'iron_ingot', // fertilizer item
+        'minecraft:iron_ingot', // fertilizer item
         10, // min growth ticks applied
         20 // max growth ticks applied
         // ex: 10 to 20 ticks will be randomly given to the crop

--- a/wiki/addons/third-party/kubejs-farmers-delight/page.kubedoc
+++ b/wiki/addons/third-party/kubejs-farmers-delight/page.kubedoc
@@ -6,7 +6,7 @@ This addon allows you to register custom knifes, pies, feasts and modify [Farmer
 
 Here's an example of registering custom knifes, pies and feasts (put this in {st-s}):
 ```js
-StartupEvents.registry("block", event => {
+StartupEvents.registry('block', event => {
   event.create('example_pie', 'farmersdelight:pie')
     .sliceItem('kubejs:example_pie_slice')
     .displayName('Example Pie')
@@ -16,7 +16,7 @@ StartupEvents.registry("block", event => {
     .displayName('Example Feast')
 })
 
-StartupEvents.registry("item", event => {
+StartupEvents.registry('item', event => {
   event.create('example_knife', 'farmersdelight:knife')
     .displayName('Example Knife')
     .tier('diamond')
@@ -27,22 +27,22 @@ Here's an example of adding custom recipes (put this in {se-s}):
 ```js
 ServerEvents.recipes(event => {
 	event.recipes.farmersdelight.cutting(
-        "minecraft:cobblestone",
-        "#forge:tools/pickaxes", // tool
+        'minecraft:cobblestone',
+        '#forge:tools/pickaxes', // tool
         [ // results
-            "minecraft:iron_ore",
-            Item.of("minecraft:diamond")
+            'minecraft:iron_ore',
+            Item.of('minecraft:diamond')
                 .withChance(0.1)
         ],
-        // "" // sound
+        // '' // sound
 	);
 
 	event.recipes.farmersdelight.cooking(
-	    ["minecraft:cobblestone"],
-	    "minecraft:iron_ore", // output
+	    ['minecraft:cobblestone'],
+	    'minecraft:iron_ore', // output
 	    30, // exp
 	    10, // cookTime
-	    "minecraft:bowl", // container
+	    'minecraft:bowl', // container
 	);
 })
 ```

--- a/wiki/addons/third-party/kubejs-industrial-foregoing/page.kubedoc
+++ b/wiki/addons/third-party/kubejs-industrial-foregoing/page.kubedoc
@@ -7,22 +7,22 @@ This mod lets you modify and create various recipes for [Industrial Foregoing](h
 ```js
 ServerEvents.recipes(event => {
     event.recipes.industrialforegoing.dissolution_chamber(
-        ['tnt'], // input items
-        'water', // input fluid
-        'sand', // output item
+        ['minecraft:tnt'], // input items
+        'minecraft:water', // input fluid
+        'minecraft:sand', // output item
         100 // time
     )
-    //     .outputFluid('water'); // output fluid
+    //     .outputFluid('minecraft:water'); // output fluid
 
     event.recipes.industrialforegoing.fluid_extractor(
-        'tnt', // input block
-        'sand', // output block
+        'minecraft:tnt', // input block
+        'minecraft:sand', // output block
         0.5, // break chance
-        'lava' // output fluid
+        'minecraft:lava' // output fluid
     )
 
     event.recipes.industrialforegoing.stonework_generate(
-        'tnt',
+        'minecraft:tnt',
         100, // water needed
         100, // lava needed
         50, // water consumed
@@ -30,25 +30,25 @@ ServerEvents.recipes(event => {
     )
     event.recipes.industrialforegoing.crusher(
         // the pickaxe action in the stonework factory
-        'tnt', // input item
-        'sand' // output item
+        'minecraft:tnt', // input item
+        'minecraft:sand' // output item
     )
 
     event.recipes.industrialforegoing.laser_drill_ore(
-        'tnt', // output
-        'sand', // catalyst
+        'minecraft:tnt', // output
+        'minecraft:sand', // catalyst
         [
             //rarity, see below for more details
             {
                 blacklist: {
-                    type: 'worldgen/biome',
+                    type: 'minecraft:worldgen/biome',
                     values: [
-                        'the_end',
-                        'the_void',
-                        'small_end_islands',
-                        'end_barrens',
-                        'end_highlands',
-                        'end_midlands'
+                        'minecraft:the_end',
+                        'minecraft:the_void',
+                        'minecraft:small_end_islands',
+                        'minecraft:end_barrens',
+                        'minecraft:end_highlands',
+                        'minecraft:end_midlands'
                     ]
                 },
                 depth_max: 16,
@@ -59,14 +59,14 @@ ServerEvents.recipes(event => {
             },
             {
                 blacklist: {
-                    type: 'worldgen/biome',
+                    type: 'minecraft:worldgen/biome',
                     values: [
-                        'the_end',
-                        'the_void',
-                        'small_end_islands',
-                        'end_barrens',
-                        'end_highlands',
-                        'end_midlands'
+                        'minecraft:the_end',
+                        'minecraft:the_void',
+                        'minecraft:small_end_islands',
+                        'minecraft:end_barrens',
+                        'minecraft:end_highlands',
+                        'minecraft:end_midlands'
                     ]
                 },
                 depth_max: 255,
@@ -78,20 +78,20 @@ ServerEvents.recipes(event => {
     )
 
     event.recipes.industrialforegoing.laser_drill_fluid(
-        'water', // output
-        'sand', // catalyst
+        'minecraft:water', // output
+        'minecraft:sand', // catalyst
         [
             // rarity, see wiki for more details
             {
                 blacklist: {
-                    type: 'worldgen/biome',
+                    type: 'minecraft:worldgen/biome',
                     values: [
-                        'the_end',
-                        'the_void',
-                        'small_end_islands',
-                        'end_barrens',
-                        'end_highlands',
-                        'end_midlands'
+                        'minecraft:the_end',
+                        'minecraft:the_void',
+                        'minecraft:small_end_islands',
+                        'minecraft:end_barrens',
+                        'minecraft:end_highlands',
+                        'minecraft:end_midlands'
                     ]
                 },
                 depth_max: 16,
@@ -101,14 +101,14 @@ ServerEvents.recipes(event => {
             },
             {
                 blacklist: {
-                    type: 'worldgen/biome',
+                    type: 'minecraft:worldgen/biome',
                     values: [
-                        'the_end',
-                        'the_void',
-                        'small_end_islands',
-                        'end_barrens',
-                        'end_highlands',
-                        'end_midlands'
+                        'minecraft:the_end',
+                        'minecraft:the_void',
+                        'minecraft:small_end_islands',
+                        'minecraft:end_barrens',
+                        'minecraft:end_highlands',
+                        'minecraft:end_midlands'
                     ]
                 },
                 depth_max: 255,
@@ -117,7 +117,7 @@ ServerEvents.recipes(event => {
                 whitelist: {}
             }
         ],
-        'zombie' // entity required below
+        'minecraft:zombie' // entity required below
     )
 })
 ```

--- a/wiki/addons/third-party/kubejs-powah/page.kubedoc
+++ b/wiki/addons/third-party/kubejs-powah/page.kubedoc
@@ -6,24 +6,24 @@ This addon allows you to create custom Energizing Orb recipes (among other thing
 ```js
 ServerEvents.recipes(event => {
     // .energizing([inputs, ...], output, energy)
-	event.recipes.powah.energizing(["minecraft:cobblestone"], "minecraft:tnt", 1000)
+	event.recipes.powah.energizing(['minecraft:cobblestone'], 'minecraft:tnt', 1000)
 })
 
 PowahEvents.registerCoolants(event => {
     // .addFluid(fluid, coolness)
-	event.addFluid("minecraft:lava", 10);
+	event.addFluid('minecraft:lava', 10);
     
     // .addSolid(fluid, coolness)
-	event.addSolid("minecraft:cobblestone", 10);
+	event.addSolid('minecraft:cobblestone', 10);
 })
 
 PowahEvents.registerHeatSource(event => {
     // .add(block, hotness)
-	event.add("minecraft:cobblestone", 10);
+	event.add('minecraft:cobblestone', 10);
 })
 
 PowahEvents.registerMagmaticFluid(event => {
     // .add(fluid, hotness)
-	event.add("minecraft:water", 10);
+	event.add('minecraft:water', 10);
 })
 ```

--- a/wiki/addons/third-party/kubejs-projecte/page.kubedoc
+++ b/wiki/addons/third-party/kubejs-projecte/page.kubedoc
@@ -8,33 +8,33 @@ Server side events ({se-s}):
 ```js
 ProjectEEvents.setEMC(event => {
     // sets the absolute emc value of an item
-    event.setEMC("minecraft:cobblestone", 0) // alias. setEMCAfter
+    event.setEMC('minecraft:cobblestone', 0) // alias. setEMCAfter
 
     // sets the emc of an item before anything else happens
     // this can sometimes result in this emc value not being
     // set, but also it allows for emc values to be generated
     // from this one; i.e crafting recipes
-    event.setEMCBefore("minecraft:stick", 10000);
+    event.setEMCBefore('minecraft:stick', 10000);
 })
 
-ItemEvents.rightClicked("minecraft:stick", event => {
+ItemEvents.rightClicked('minecraft:stick', event => {
     let player = event.player;
 
     // getPlayerEMC will always return a string
     // because emc values can get very large
-    player.tell("Your emc is " + ProjectE.getPlayerEMC(player))
+    player.tell('Your emc is ' + ProjectE.getPlayerEMC(player))
 
     ProjectE.addPlayerEMC(player, 1000);
     // the second argument can be a string because of the above
     // ProjectE.setPlayerEMC also exists
 
-    player.tell("Your new emc is " + ProjectE.getPlayerEMC(player))
+    player.tell('Your new emc is ' + ProjectE.getPlayerEMC(player))
 })
 ```
 
 Startup events ({st-s}):
 ```js
 ProjectEEvents.registerWorldTransmutations(event => {
-    event.transform("minecraft:tnt", "minecraft:oak_planks");
+    event.transform('minecraft:tnt', 'minecraft:oak_planks');
 })
 ```

--- a/wiki/addons/third-party/lootjs/page.kubedoc
+++ b/wiki/addons/third-party/lootjs/page.kubedoc
@@ -2,4 +2,4 @@ Download: [CurseForge](https://www.curseforge.com/minecraft/mc-mods/lootjs), [Mo
 
 ---
 
-LootJS has [its own wiki](https://github.com/AlmostReliable/lootjs/wiki).
+LootJS has its own wiki, which you can find [here](https://github.com/AlmostReliable/lootjs/wiki).

--- a/wiki/addons/third-party/morejs/page.kubedoc
+++ b/wiki/addons/third-party/morejs/page.kubedoc
@@ -2,4 +2,4 @@ Download: [CurseForge](https://www.curseforge.com/minecraft/mc-mods/morejs)
 
 ---
 
-MoreJS has its own wiki, you can find it [here](https://github.com/AlmostReliable/morejs/wiki).
+MoreJS has its own wiki, which you can find [here](https://github.com/AlmostReliable/morejs/wiki).

--- a/wiki/addons/third-party/probejs/dynamic-document-modification/page.kubedoc
+++ b/wiki/addons/third-party/probejs/dynamic-document-modification/page.kubedoc
@@ -34,7 +34,7 @@ Recommended to read with [[/addons/third-party/probejs/document-properties]].
 ```js
 ProbeJSEvents.generateDoc(event => {
     // So we will load the class and tell ProbeJS that we will transform the document of it
-    event.transformDocument(Java.loadClass("dev.latvian.mods.kubejs.recipe.RecipeJS"), document => {
+    event.transformDocument(Java.loadClass('dev.latvian.mods.kubejs.recipe.RecipeJS'), document => {
 
         // Find the first method with name "stage", it is also possible to find others by having more conditions
         document.methods.find(method => method.name == "stage")

--- a/wiki/addons/third-party/probejs/page.kubedoc
+++ b/wiki/addons/third-party/probejs/page.kubedoc
@@ -17,9 +17,9 @@ Usage:
 . Also, try to type like `@item` or `@block` to see snippets generated.
 
 In case nothing shows up in VSCode, check that:
-- Many JSON files started with "probe" in the .vscode folder are under your .minecraft folder.
-- There is a "probe" folder under the KubeJS folder, and many files ending with ".d.ts" are in the folder.
-- All ".d.ts" files don't have syntax errors indicated by VSCode.
+- Many JSON files started with `probe` in the .vscode folder are under your .minecraft folder.
+- There is a `probe` folder under the KubeJS folder, and many files ending with `.d.ts` are in the folder.
+- All `.d.ts` files don't have syntax errors indicated by VSCode.
 
 
 If all three steps are correct, you might need to configure your VSCode to make it accepts how ProbeJS dumps the typing, or just the VSCode can't handle the JS project created by ProbeJS.

--- a/wiki/addons/third-party/screenjs/page.kubedoc
+++ b/wiki/addons/third-party/screenjs/page.kubedoc
@@ -112,7 +112,7 @@ The custom KeyBind event is a client event.
 
 ```js
 KeybindEvents.register(event => {
-    event.register(new KeyBind("open_menu" /* name */, InputConstants.KEY_G /* key index, opengl spec */, "screenjs" /* category name */), (action, modifiers /* modifiers as per OpenGL spec */) => {
+    event.register(new KeyBind('open_menu' /* name */, InputConstants.KEY_G /* key index, opengl spec */, 'screenjs' /* category name */), (action, modifiers /* modifiers as per OpenGL spec */) => {
         if (action == 1) { // action == 1 is PRESS
             Minecraft.instance.gui.setOverlayMessage(Text.string('AAA').yellow(), false) // vanilla method
             MenuScreens.create('kubejs:separate', Minecraft.instance, 1000, Text.string('AAA').yellow()) // opens a GUI container, preferably of type 'basic'

--- a/wiki/folder-structure/data/page.kubedoc
+++ b/wiki/folder-structure/data/page.kubedoc
@@ -1,2 +1,4 @@
 The `data` folder acts just like the `data` folder inside of a datapack - however, it will always load - you can't disable it from loading in any way.
 Just like normal datapacks, it can be reloaded by running `/reload`.
+
+Also on KubeJS 6.1+, you can drop a datapack `.zip` into the `data` folder to load it.

--- a/wiki/other/contributing/en.yml
+++ b/wiki/other/contributing/en.yml
@@ -1,3 +1,5 @@
 title: "Contributing to Wiki"
 
 contributing: "You can check out [[/test]] to see all the things that are possible with this wiki."
+formatting: "Formatting Rules"
+formatting-info: "To make the wiki easier to follow, all code should be formatted like this:"

--- a/wiki/other/contributing/page.kubedoc
+++ b/wiki/other/contributing/page.kubedoc
@@ -1,1 +1,7 @@
 {contributing}
+
+# {formatting}
+{formatting-info}
+>>> danger
+WIP
+<<<

--- a/wiki/other/major-updates/6.0/page.kubedoc
+++ b/wiki/other/major-updates/6.0/page.kubedoc
@@ -118,5 +118,5 @@ None of the vanilla classes are wrappers anymore - `EntityJS`, `LevelJS`, `ItemS
 
 # Other questions
 
-If you have any other questions, feel free to ask them on my [Discord Server](https://discord.gg/latviandev).
-You can find out info about [[/intro/major-updates/6.1|next update here]].
+If you have any other questions, feel free to ask them on my [Discord Server]({discord-url}).
+You can find out info about [[/other/major-updates/6.1|next update here]].

--- a/wiki/tutorials/block-modification/page.kubedoc
+++ b/wiki/tutorials/block-modification/page.kubedoc
@@ -1,8 +1,8 @@
 You can change properties of existing blocks:
 
 ```js
-BlockEvents.modification(e => {
-  e.modify('minecraft:stone', block => {
+BlockEvents.modification(event => {
+  event.modify('minecraft:stone', block => {
     block.destroySpeed = 0.1
     block.hasCollision = false
   })

--- a/wiki/tutorials/block-registry/page.kubedoc
+++ b/wiki/tutorials/block-registry/page.kubedoc
@@ -1,8 +1,8 @@
 You can register many types of custom blocks in KubeJS. Here's the simplest way:
 
 ```js
-StartupEvents.registry("block", (event) => {
-  event.create("example_block") // Create a new block with ID "kubejs:example_block"
+StartupEvents.registry('block', event => {
+  event.create('example_block') // Create a new block with ID 'kubejs:example_block'
 })
 ```
 
@@ -11,8 +11,8 @@ That's it! Launch the game, and assuming you've left KubeJS' auto-generated reso
 To make modifications to this block, we use the [[$BlockBuilder|block builder]] returned by the `[js]event.create()` call. The block builder allows us to chain together multiple modifications. Let's try making some of the more common modifications:
 
 ```js
-StartupEvents.registry('block', (event) => {
-    event.create('example_block') // Create a new block
+StartupEvents.registry('block', event => {
+  event.create('example_block') // Create a new block
     .displayName('My Custom Block') // Set a custom name
     .soundType('wool') // Set a material (affects the sounds and some properties)
     .hardness(1.0) // Set hardness (affects mining time)
@@ -20,8 +20,8 @@ StartupEvents.registry('block', (event) => {
     .tagBlock('my_custom_tag') // Tag the block with `#minecraft:my_custom_tag` (can have multiple tags)
     .requiresTool(true) // Requires a tool or it won't drop (see tags below)
     .tagBlock('my_namespace:my_other_tag') // Tag the block with `#my_namespace:my_other_tag`
-    .tagBlock('mineable/axe') //can be mined faster with an axe
-    .tagBlock('mineable/pickaxe') // or a pickaxe
+    .tagBlock('minecraft:mineable/axe') //can be mined faster with an axe
+    .tagBlock('minecraft:mineable/pickaxe') // or a pickaxe
     .tagBlock('minecraft:needs_iron_tool') // the tool tier must be at least iron
 })
 ```

--- a/wiki/tutorials/changing-mod-names/en.yml
+++ b/wiki/tutorials/changing-mod-names/en.yml
@@ -1,6 +1,7 @@
 title: "Changing Mod Display Names"
 description: "Yes, it's cursed, but possible!"
 
+version-info: "This is only possible on KubeJS 6 and above."
 startup-line: "In a startup script, add this line:"
 useful: "This is useful when you add a bunch of items with KubeJS but want them to show your modpack name instead of \"KubeJS\""
 other-mods: "And yes, you can change name of other mods as well:"

--- a/wiki/tutorials/changing-mod-names/page.kubedoc
+++ b/wiki/tutorials/changing-mod-names/page.kubedoc
@@ -1,3 +1,7 @@
+>>> info
+{version-info}
+<<<
+
 {startup-line}
 
 ```js

--- a/wiki/tutorials/custom-tiers/page.kubedoc
+++ b/wiki/tutorials/custom-tiers/page.kubedoc
@@ -4,7 +4,7 @@ They are not reloadable without restarting the game.
 # Tool Tiers
 
 ```js
-ItemEvents.toolTierRegistry (event => {
+ItemEvents.toolTierRegistry(event => {
   event.add('tier_id', tier => {
     tier.uses = 250
     tier.speed = 6.0
@@ -19,7 +19,7 @@ ItemEvents.toolTierRegistry (event => {
 # Armor Tiers
 
 ```js
-ItemEvents.armorTierRegistry (event => {
+ItemEvents.armorTierRegistry(event => {
   event.add('tier_id', tier => {
     tier.durabilityMultiplier = 15 // Each slot will be multiplied with [13, 15, 16, 11]
     tier.slotProtections = [2, 5, 6, 2] // Slot indicies are [FEET, LEGS, BODY, HEAD]

--- a/wiki/tutorials/item-modification/page.kubedoc
+++ b/wiki/tutorials/item-modification/page.kubedoc
@@ -5,16 +5,16 @@ ItemEvents.modification(event => {
   event.modify('minecraft:ender_pearl', item => {
     item.maxStackSize = 64
     item.fireResistant = true
-    item.rarity = "UNCOMMON"
+    item.rarity = 'UNCOMMON'
   })
 
   event.modify('minecraft:ancient_debris', item => {
-    item.rarity = "RARE"
+    item.rarity = 'RARE'
     item.burnTime = 16000
   })
 
   event.modify('minecraft:turtle_helmet', item => {
-    item.rarity = "EPIC"
+    item.rarity = 'EPIC'
     item.maxDamage = 481
     item.craftingRemainder = Item.of('minecraft:scute').item
   })
@@ -57,7 +57,7 @@ Turtle only has helmet slot and Elytra only has chestplate slot.
 ## Tools
 ```js
 ItemEvents.modification(event => {
-  event.modify('golden_sword', item => {
+  event.modify('minecraft:golden_sword', item => {
     item.tier = tier => {
         tier.speed = 12
         tier.attackDamageBonus = 10
@@ -66,7 +66,7 @@ ItemEvents.modification(event => {
     }
   })
 
-  event.modify('wooden_sword', item => {
+  event.modify('minecraft:wooden_sword', item => {
     item.tier = tier => {
         tier.enchantmentValue = 30
     }
@@ -86,11 +86,11 @@ ItemEvents.modification(event => {
         food.hunger(2)
         food.saturation(3)
         food.fastToEat()
-        food.eaten(e => e.player.tell('you ate')) // this is broken, use ItemEvents.foodEaten instead.
+        food.eaten(foodData => foodData.player.tell('you ate')) // this is broken, use ItemEvents.foodEaten instead.
     }
   })
 
-  event.modify('pumpkin_pie', item => {
+  event.modify('minecraft:pumpkin_pie', item => {
     item.foodProperties = null // make pumpkin pies inedible
   })
 })

--- a/wiki/tutorials/recipes/page.kubedoc
+++ b/wiki/tutorials/recipes/page.kubedoc
@@ -261,7 +261,7 @@ Here's a helper function, which allows you to make items by crafting a flower po
 
 ```js
 ServerEvents.recipes(event => {
-  let potting = (output, pottedInput) => {
+  function potting(output, pottedInput) {
     event.shaped(output, [
       'BIB',
       ' B '


### PR DESCRIPTION
The most notable change of this PR is **The Big Reformat** which should've made most of the code on the wiki have consistant formatting.

Other changes:
* rewrote the KubeJS Mekanism and KubeJS Immersive Engineering pages
* fixed one entry on the KubeJS Thermal page not showing up correctly
* rewrote the LootJS and MoreJS pages
* changed some formatting in the ProbeJS page
* added a mention of being able to drag and drop datapacks zips into the `data` folder to the `/data` page
* added a mention about the formatting roles to the "Contributing to the Wiki" page, however I did not write them as @LatvianModder said that he'll do it
* fixed the discord link and 6.1 wiki page link in the KubeJS 6.0 update page
* added a mention to the "Changing Mod Names" page saying that it's only possible on KubeJS 6+