### PR TITLE
fixed mob effect page

### DIFF
--- a/wiki/tutorials/mob-effect-registry/page.kubedoc
+++ b/wiki/tutorials/mob-effect-registry/page.kubedoc
@@ -3,39 +3,39 @@ You can create custom Mob Effects:
 |> 1.19.2+
 ```js
 StartupEvents.registry('mob_effect', event => {
-    event.create('custom_effect') // Create the effect under "kubejs:custom_effect"
-        .color(0x000000) // Sets the color of the Effect's Particles.
-        .beneficial() // Categorizes the Effect as Beneficial.
-        .effectTick((entity, lvl) => { // This useful for reoccurring logic while the entity is under the effect.
-            // Heal the entity once a second scaled by the effect's level, much like regeneration.
-            if (entity.age % 20 != 0) return
-            entity.heal(1 * lvl)
-        })
-        // modifyAttribute is useful to scale an entity's attributes only lasting while under the effect
-        .modifyAttribute('minecraft:generic.attack_damage', // The attribute to scale
-            'e0f4e796-3d3d-11ee-be56-0242ac183754',//Some random UUID which serves as the effect's unique instance
-            1, // The amount to increase/decrease by
-            "multiply_base" // The operation to perform
-        )
+  event.create('custom_effect') // Create the effect under "kubejs:custom_effect"
+    .color(0x000000) // Sets the color of the Effect's Particles.
+    .beneficial() // Categorizes the Effect as Beneficial.
+    .effectTick((entity, lvl) => { // This useful for reoccurring logic while the entity is under the effect.
+      // Heal the entity once a second scaled by the effect's level, much like regeneration.
+      if (entity.age % 20 != 0) return
+      entity.heal(1 * lvl)
+    })
+    // modifyAttribute is useful to scale an entity's attributes only lasting while under the effect
+    .modifyAttribute('minecraft:generic.attack_damage', // The attribute to scale
+      'e0f4e796-3d3d-11ee-be56-0242ac183754',//Some random UUID which serves as the effect's unique instance
+      1, // The amount to increase/decrease by
+      "multiply_base" // The operation to perform
+    )
 })
 ```
 <||> 1.18.2 and below
 ```js
 onEvent('mob_effect.registry', event => {
-    event.create('custom_effect') // Create the effect under "kubejs:custom_effect"
-        .color(0x000000) // Sets the color of the Effect's Particles.
-        .harmful() // Categorizes the Effect as Harmful.
-        .effectTick((entity, lvl) => { // This useful for reoccurring logic while the entity is under the effect.
-            // Heal the entity once a second scaled by the effect's level, much like regeneration.
-            if (entity.age % 20 != 0) return
-            entity.heal(1 * lvl)
-        })
-        // modifyAttribute is useful to scale an entity's attributes only lasting while under the effect
-        .modifyAttribute('minecraft:generic.attack_damage', // The attribute to scale
-            'e0f4e796-3d3d-11ee-be56-0242ac183754',//Some random UUID which serves as the effect's unique instance
-            1, // The amount to increase/decrease by
-            "multiply_base" // The operation to perform
-        )
+  event.create('custom_effect') // Create the effect under "kubejs:custom_effect"
+    .color(0x000000) // Sets the color of the Effect's Particles.
+    .harmful() // Categorizes the Effect as Harmful.
+    .effectTick((entity, lvl) => { // This useful for reoccurring logic while the entity is under the effect.
+      // Heal the entity once a second scaled by the effect's level, much like regeneration.
+      if (entity.age % 20 != 0) return
+      entity.heal(1 * lvl)
+    })
+    // modifyAttribute is useful to scale an entity's attributes only lasting while under the effect
+    .modifyAttribute('minecraft:generic.attack_damage', // The attribute to scale
+      'e0f4e796-3d3d-11ee-be56-0242ac183754',//Some random UUID which serves as the effect's unique instance
+      1, // The amount to increase/decrease by
+      "multiply_base" // The operation to perform
+    )
 })
 ```
 <|

--- a/wiki/tutorials/mob-effect-registry/page.kubedoc
+++ b/wiki/tutorials/mob-effect-registry/page.kubedoc
@@ -3,27 +3,39 @@ You can create custom Mob Effects:
 |> 1.19.2+
 ```js
 StartupEvents.registry('mob_effect', event => {
-  event.create('custom_effect') // Create the Effect. Can also have Types, but vanilla Kube has none.
-    .color(0x000000) // Sets the color of the Effect's Particles.
-    .beneficial() // Categorizes the Effect as Beneficial.
-    .effectTick(ctx => { // EffectTick is where the magic happens. It has tooooons of methods for you to use, which activate every Tick.
-      ctx.absorptionAmount = 2 // For example, this will apply an Absorption heart.
-      ctx.modifyAttribute('minecraft:generic.max_health', 'identifier', 1, 'addition') // This modifies an Attribute, which will increase an Entity's Max Health by 1 HP.
-    })
-    .modifyAttribute() // This method can also be used here, but is not recommended because the modified Attribute continues to stay modified until the Entity dies.
+    event.create('custom_effect') // Create the effect under "kubejs:custom_effect"
+        .color(0x000000) // Sets the color of the Effect's Particles.
+        .beneficial() // Categorizes the Effect as Beneficial.
+        .effectTick((entity, lvl) => { // This useful for reoccurring logic while the entity is under the effect.
+            // Heal the entity once a second scaled by the effect's level, much like regeneration.
+            if (entity.age % 20 != 0) return
+            entity.heal(1 * lvl)
+        })
+        // modifyAttribute is useful to scale an entity's attributes only lasting while under the effect
+        .modifyAttribute('minecraft:generic.attack_damage', // The attribute to scale
+            'e0f4e796-3d3d-11ee-be56-0242ac183754',//Some random UUID which serves as the effect's unique instance
+            1, // The amount to increase/decrease by
+            "multiply_base" // The operation to perform
+        )
 })
 ```
 <||> 1.18.2 and below
 ```js
 onEvent('mob_effect.registry', event => {
-  event.create('custom_effect') // Create the Effect. Can also have Types, but vanilla Kube has none.
-    .color(0x000000) // Sets the color of the Effect's Particles.
-    .beneficial() // Categorizes the Effect as Beneficial.
-    .effectTick(ctx => { // EffectTick is where the magic happens. It has tooooons of methods for you to use, which activate every Tick.
-      ctx.absorptionAmount = 2 // For example, this will apply an Absorption heart.
-      ctx.modifyAttribute('minecraft:generic.max_health', 'identifier', 1, 'addition') // This modifies an Attribute, which will increase an Entity's Max Health by 1 HP.
-    })
-    .modifyAttribute() // This method can also be used here, but is not recommended because the modified Attribute continues to stay modified until the Entity dies.
+    event.create('custom_effect') // Create the effect under "kubejs:custom_effect"
+        .color(0x000000) // Sets the color of the Effect's Particles.
+        .harmful() // Categorizes the Effect as Harmful.
+        .effectTick((entity, lvl) => { // This useful for reoccurring logic while the entity is under the effect.
+            // Heal the entity once a second scaled by the effect's level, much like regeneration.
+            if (entity.age % 20 != 0) return
+            entity.heal(1 * lvl)
+        })
+        // modifyAttribute is useful to scale an entity's attributes only lasting while under the effect
+        .modifyAttribute('minecraft:generic.attack_damage', // The attribute to scale
+            'e0f4e796-3d3d-11ee-be56-0242ac183754',//Some random UUID which serves as the effect's unique instance
+            1, // The amount to increase/decrease by
+            "multiply_base" // The operation to perform
+        )
 })
 ```
 <|


### PR DESCRIPTION
The old effects page displayed wrong information about how to modify attributes and was also lacking information such as being able to call the effect's level in the effectTick callback.