### PR TITLE
Update computer addons

### DIFF
--- a/wiki/addons/cc-tweaked/meta.yml
+++ b/wiki/addons/cc-tweaked/meta.yml
@@ -1,4 +1,4 @@
-author: "5E530423"
+author: "F07631B3"
 addon: "third-party"
 download-curseforge: "kubejs-cc"
 download-modrinth: "kubejs+cc-tweaked"

--- a/wiki/addons/cc-tweaked/page.kubedoc
+++ b/wiki/addons/cc-tweaked/page.kubedoc
@@ -1,1 +1,1 @@
-You can find more info about this mod on its wiki found [here](https://github.com/wolfieboy09/KubeJS-CC-1.20.1/wiki).
+You can find more info about this mod on its wiki found [here](https://github.com/wolfieboy09/KubeJS-CC-1.20.1/wiki). Supports versions `1.20.1` and `1.19.2`

--- a/wiki/addons/computer-craft/page.kubedoc
+++ b/wiki/addons/computer-craft/page.kubedoc
@@ -1,0 +1,1 @@
+Supports version `1.18.2`. For more modern versions, consider using [KubeJS + CC: Tweaked](https://kubejs.com/wiki/addons/cc-tweaked)


### PR DESCRIPTION
The mod **KubeJS ComputerCraft** orignally made by Pruno only supports **1.18.2**.
The mod **KubeJS + CC: Tweaked** supports (currently) both **1.20.1** and **1.19.2**, which is more "up-to-date"

The wiki had Pruno listed as authors of both mods.

This PR Changes:
- The author of the KJSCC (the more "modern" one)
- Adds some docs to both pages