### PR TITLE
Add 1.21 hint on RecipeViewerEvents page

### DIFF
--- a/wiki/events/RecipeViewerEvents/page.kubedoc
+++ b/wiki/events/RecipeViewerEvents/page.kubedoc
@@ -1,3 +1,7 @@
+>>> info
+RecipeViewerEvents are only available on version 1.21 and above.
+<<<
+
 # About
 These events allow you to modify recipe viewer mods all at once with the same events!
 Currently supported mods:

--- a/wiki/events/RecipeViewerEvents/page.kubedoc
+++ b/wiki/events/RecipeViewerEvents/page.kubedoc
@@ -1,5 +1,5 @@
 >>> info
-RecipeViewerEvents are only available on version 1.21 and above.
+RecipeViewerEvents is only available on version 1.21 and above.
 <<<
 
 # About


### PR DESCRIPTION
I'm using EMI on 1.20.1 and spent hours trying to hide a recipe using the provided examples without any luck. I only discovered that RecipeViewerEvents are supported on 1.21+ because I went to the Discord to look for more help. This adds that information at the top of the page so that others don't end up doing the same thing I did.