### PR TITLE
Update Persistent Data article

### DIFF
--- a/wiki/tips/persistent-data/page.kubedoc
+++ b/wiki/tips/persistent-data/page.kubedoc
@@ -70,7 +70,7 @@ This is equivalent to the `[js]const tag = compound[name]` bean.
 
 ## Typed key access
 
-| Data type     | Getter                                                               | Setter                            |
+| Data type     | Setter                                                               | Getter                            |
 | Boolean       | `[js]compound.putBoolean(name, value)`                               | `[js]compound.getBoolean(name)`   |
 | Byte          | `[js]compound.putByte(name, value)`                                  | `[js]compound.getByte(name)`      |
 | Byte array    | `[js]compound['putByteArray(java.lang.String,byte[])'](name, value)` | `[js]compound.getByteArray(name)` |


### PR DESCRIPTION
This PR:
- adds code examples for 1.21.1 and 1.20.1 - the existing code block is for 1.20.4 and old version of KubeJS 1.21.1.
- Adds documentation about non-bean methods of manipulating compound tags, like `persistentData` is.