### PR TITLE
Add modrinth link for MoreJS

### DIFF
--- a/wiki/addons/morejs/meta.yml
+++ b/wiki/addons/morejs/meta.yml
@@ -1,3 +1,4 @@
 author: "E7091D7E"
 addon: "third-party"
 download-curseforge: "morejs"
+download-modrinth: "morejs"


### PR DESCRIPTION
MoreJS is available on Modrinth, so the link should be added.